### PR TITLE
Enforce 100% code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /Godeps/_workspace
 /Godeps/Readme
 /.godep-install
-/reports
+/test.cov

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
 default: test
 
 test: unit-test
-	mkdir -p reports/cov reports/unit
-	godep go test -coverprofile reports/gocumber.cov -v . > reports/gocumber.txt
-	[ ! -f reports/gocumber.cov ] || gocov convert reports/gocumber.cov | gocov-xml > reports/cov/gocumber.xml
-	[ ! -f reports/gocumber.cov ] || gocov convert reports/gocumber.cov | gocov-html > reports/cov/gocumber.html
-	[ ! -f reports/gocumber.txt ] || go-junit-report < reports/gocumber.txt > reports/unit/gocumber.xml
+	@godep go test -coverprofile ./test.cov -v .
+	@go tool cover -func ./test.cov | awk '$$3 !~ /^100/ { print; gaps++ } END { exit gaps }'
 
 unit-test: .godep-install
 	godep go test -cover .
@@ -16,12 +13,8 @@ unit-test: .godep-install
 	touch .godep-install
 
 setup: .godep-install
-	command -v gocov > /dev/null || go get github.com/axw/gocov/...
-	command -v gocov-xml > /dev/null || go get github.com/AlekSi/gocov-xml
-	command -v gocov-html > /dev/null || go get gopkg.in/matm/v1/gocov-html
-	command -v go-junit-report > /dev/null || go get github.com/wancw/go-junit-report
 
 clean:
-	rm -rf reports
+	rm -f ./test.cov
 
 .PHONY: clean default setup test unit-test

--- a/gocumber_test.go
+++ b/gocumber_test.go
@@ -17,12 +17,15 @@ func (t FuncTestingFramework) Log(args ...interface{})   { t.log(args...) }
 
 func TestRun_HappyPath(t *testing.T) {
 	steps := make(Definitions)
+	tt := new(testing.T)
 
 	// Simply defining steps to prove that it parses right, no need to fill them in
 	steps.When("I create a user with the following json data:", func([]string, StepNode) {})
 	steps.Then("the user should be created with the expected data", func([]string, StepNode) {})
 
-	steps.Run(t, "test/valid.feature")
+	steps.Run(tt, "test/valid.feature")
+
+	assert.False(t, tt.Failed())
 }
 
 func TestRun_FailsOnMissingFile(t *testing.T) {
@@ -55,10 +58,10 @@ func TestRun_FailsOnUndefinedSteps(t *testing.T) {
 func ExampleRun_WithUndefinedSteps() {
 	steps := make(Definitions)
 
-	t := FuncTestingFramework{
+	tt := FuncTestingFramework{
 		err: func(args ...interface{}) { fmt.Println(args...) },
 	}
-	steps.Run(t, "test/valid_with_url_params.feature")
+	steps.Run(tt, "test/valid_with_url_params.feature")
 
 	// Output:
 	// Undefined step:
@@ -68,16 +71,16 @@ func ExampleRun_WithUndefinedSteps() {
 func ExampleRun_WithFailingSteps() {
 	steps := make(Definitions)
 
-	t := FuncTestingFramework{
+	tt := FuncTestingFramework{
 		err: func(args ...interface{}) { fmt.Println(args...) },
 		log: func(args ...interface{}) { fmt.Println(args...) },
 	}
 	steps.When("I create a user with the following json data:", func([]string, StepNode) {})
 	steps.Then("the user should be created with the expected data", func([]string, StepNode) {
-		t.Error("Expectation failed")
+		tt.Error("Expectation failed")
 	})
 
-	steps.Run(t, "test/valid.feature")
+	steps.Run(tt, "test/valid.feature")
 
 	// Output:
 	// Scenario: Create a user with a json payload
@@ -86,26 +89,33 @@ func ExampleRun_WithFailingSteps() {
 
 func TestRun_SuccessWithOutlineSteps(t *testing.T) {
 	steps := make(Definitions)
+	tt := new(testing.T)
 
 	steps.Given("I have no users", func([]string, StepNode) {})
 	steps.When("I create a new user with the following data:", func([]string, StepNode) {})
 	steps.Then("no users should be created", func([]string, StepNode) {})
 
-	steps.Run(t, "test/valid_with_outline.feature")
+	steps.Run(tt, "test/valid_with_outline.feature")
+
+	assert.False(t, tt.Failed())
 }
 
 func TestRun_SuccessWithPyString(t *testing.T) {
 	steps := make(Definitions)
+	tt := new(testing.T)
 
 	steps.Given("I do something the following json data:", func([]string, StepNode) {})
 	steps.When("I do something", func([]string, StepNode) {})
 	steps.Then("something should have happened", func([]string, StepNode) {})
 
-	steps.Run(t, "test/valid_with_pystring.feature")
+	steps.Run(tt, "test/valid_with_pystring.feature")
+
+	assert.False(t, tt.Failed())
 }
 
 func TestColumnMap_Happy(t *testing.T) {
 	steps := make(Definitions)
+	tt := new(testing.T)
 
 	var called bool
 	steps.When("I create something with the following table data:", func(_ []string, step StepNode) {
@@ -120,9 +130,10 @@ func TestColumnMap_Happy(t *testing.T) {
 			ColumnMap(step.Table()))
 	})
 
-	steps.Run(t, "test/valid_with_table_data.feature")
+	steps.Run(tt, "test/valid_with_table_data.feature")
 
 	assert.True(t, called)
+	assert.False(t, tt.Failed())
 }
 
 func TestExec_MatchFound(t *testing.T) {


### PR DESCRIPTION
When something isn't covered the file, line number and function name are printed after test results:

```
% make
godep go test -cover .
ok      github.com/sittercity/gocumber  0.011s  coverage: 98.5% of statements
=== RUN TestRun_HappyPath
--- PASS: TestRun_HappyPath (0.00s)
=== RUN TestRun_FailsOnMissingFile
--- PASS: TestRun_FailsOnMissingFile (0.00s)
=== RUN TestRun_FailsOnInvalidGherkin
--- PASS: TestRun_FailsOnInvalidGherkin (0.00s)
=== RUN TestRun_FailsOnUndefinedSteps
--- PASS: TestRun_FailsOnUndefinedSteps (0.00s)
=== RUN TestRun_SuccessWithOutlineSteps
--- PASS: TestRun_SuccessWithOutlineSteps (0.00s)
=== RUN TestRun_SuccessWithPyString
--- PASS: TestRun_SuccessWithPyString (0.00s)
=== RUN TestColumnMap_Happy
--- PASS: TestColumnMap_Happy (0.00s)
=== RUN TestExec_MatchFound
--- PASS: TestExec_MatchFound (0.00s)
=== RUN TestExec_NoMatch
--- PASS: TestExec_NoMatch (0.00s)
=== RUN: ExampleRun_WithUndefinedSteps
--- PASS: ExampleRun_WithUndefinedSteps (0.00s)
=== RUN: ExampleRun_WithFailingSteps
--- PASS: ExampleRun_WithFailingSteps (0.00s)
PASS
coverage: 98.5% of statements
ok      github.com/sittercity/gocumber  0.015s
github.com/sittercity/gocumber/gocumber.go:12:  unusedFunc      0.0%
total:                                          (statements)    98.5%
make: *** [test] Error 2
```